### PR TITLE
Here's how I've added comprehensive documentation for core repository…

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,67 @@
+# src/clever_bench/benchmark.py
+
+## Overview
+The `src/clever_bench/benchmark.py` file defines the `Benchmark` class and several helper functions for managing and processing Lean theorem proving problems within the Clever Lean project. Its primary role is to discover, load, parse, and provide access to these problems. It also supports exporting the benchmark problems into JSON and CSV formats. The helper functions facilitate locating necessary project directories and files.
+
+## Key Components
+- **`get_clever_lean_project_path() -> str`**: Returns the absolute path to the main Clever Lean project directory.
+- **`get_clever_lean_human_eval_directory() -> str`**: Returns the path to the directory containing Lean problems for human evaluation.
+- **`get_clever_lean_sample_examples_directory() -> str`**: Returns the path to the directory containing sample Lean problems.
+- **`get_helper_definition_file_path() -> str`**: Returns the path to the `AllImports.lean` file, which contains helper definitions used by the problems.
+- **`Benchmark` class**:
+    - `__init__(self, directory: str = None, helper_definition_file: str = None, is_sample: bool = False)`: Initializes a new `Benchmark` instance. It sets up paths to problem directories and helper files. The `is_sample` flag determines whether to load standard human evaluation problems or sample problems.
+    - `load_all(self)`: Discovers and loads all `.lean` problem files from the configured directory. It uses `LeanSpecParser` to parse each file into a `LeanProblem` object and stores them.
+    - `get_problem(self, idx: int) -> LeanProblem`: Retrieves a specific `LeanProblem` by its numerical ID.
+    - `to_json(self) -> str`: Serializes the list of loaded `LeanProblem` objects into a JSON formatted string.
+    - `to_csv(self) -> Tuple[List[str], List[List[str]]]`: Converts the list of `LeanProblem` objects into a CSV format, returning a tuple containing headers and a list of rows.
+    - `save_json(self, filepath: str)`: Saves the benchmark problems to a specified JSON file.
+    - `save_csv(self, filepath: str)`: Saves the benchmark problems to a specified CSV file.
+
+## Important Variables/Constants
+- **`Benchmark.project_path: str`**: Stores the path to the Clever Lean project.
+- **`Benchmark.directory: str`**: The directory from which `.lean` problem files are loaded.
+- **`Benchmark.helper_definition_file: str`**: Path to the Lean file containing common helper definitions.
+- **`Benchmark.is_sample: bool`**: A boolean flag indicating if the benchmark is for sample problems or standard evaluation problems.
+- **`Benchmark.problems: List[LeanProblem]`**: A list that holds all the loaded and parsed `LeanProblem` instances.
+
+## Usage Examples
+```python
+from clever_bench.benchmark import Benchmark
+
+# Initialize a benchmark for the standard human evaluation problems
+human_eval_benchmark = Benchmark()
+human_eval_benchmark.load_all()
+
+# Access a specific problem by its ID
+if len(human_eval_benchmark.problems) > 0:
+    problem_0 = human_eval_benchmark.get_problem(0)
+    print(f"Problem 0 Name: {problem_0.name}")
+    print(f"Problem 0 Full Theorem: {problem_0.full_theorem}")
+
+# Save the loaded problems to a JSON file
+human_eval_benchmark.save_json("human_eval_problems.json")
+
+# Save the loaded problems to a CSV file
+human_eval_benchmark.save_csv("human_eval_problems.csv")
+
+# Initialize a benchmark for sample problems
+sample_benchmark = Benchmark(is_sample=True)
+sample_benchmark.load_all()
+
+# Get the number of sample problems loaded
+print(f"Number of sample problems: {len(sample_benchmark.problems)}")
+
+# Save sample problems
+sample_benchmark.save_json("sample_problems.json")
+```
+
+## Dependencies and Interactions
+- **`os`**: Used for operating system-dependent functionalities like path construction (e.g., `os.path.join`, `os.path.dirname`).
+- **`json`**: Used for serializing problem data to JSON format (`json.dumps`).
+- **`csv`**: Used for serializing problem data to CSV format (`csv.writer`).
+- **`typing.List`, `typing.Tuple`**: Used for type hinting to improve code readability and maintainability.
+- **`pathlib.Path`**: Used for object-oriented path manipulation and for finding all `.lean` files in a directory (`Path(self.directory).glob("*.lean")`).
+- **`clever_bench.lean_problem.LeanProblem`**: This class (defined in another module within the same project) represents a single parsed Lean problem. The `Benchmark` class creates and manages a list of `LeanProblem` objects.
+- **`clever_bench.lean_parser_spec.LeanSpecParser`**: This class (also from the same project) is responsible for parsing the content of `.lean` files and extracting problem specifications. The `Benchmark.load_all()` method utilizes this parser.
+- **Lean files (`.lean`)**: The script reads `.lean` files from specified directories. The structure and content of these files are crucial for the `LeanSpecParser` to work correctly.
+- **`AllImports.lean`**: A specific Lean file that contains helper definitions, which can be included during the parsing of individual problems.

--- a/docs/lakefile.md
+++ b/docs/lakefile.md
@@ -1,0 +1,64 @@
+# src/lean4/lakefile.lean
+
+## Overview
+The `src/lean4/lakefile.lean` file is the build configuration script for the Lean 4 project named "clever". It is used by `lake`, Lean's official build system and package manager, to understand the project's structure, compile its source files, manage dependencies, and define build targets. This file essentially instructs `lake` on how to build the "clever" software.
+
+## Key Components
+The `lakefile.lean` uses a Domain Specific Language (DSL) provided by Lake to define the build configuration. Key parts of this file include:
+
+- **`import Lake` and `open Lake DSL`**:
+    - These lines import the necessary Lake modules and open the DSL namespace, making Lake's configuration commands directly available.
+
+- **`package «clever» where ...`**:
+    - This block defines the main package for the project, named "clever".
+    - **`leanOptions := #[ ⟨\`autoImplicit, false⟩ ]`**: This is a specific configuration for the Lean compiler when building this package. It sets the `autoImplicit` option to `false`. This means that the compiler will not automatically infer implicit arguments for functions and definitions; they must be declared explicitly. This can make code more verbose but often clearer and less prone to certain types of errors.
+
+- **`require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.15.0"`**:
+    - This line declares an external dependency on the `mathlib4` library, which is a comprehensive library of formalized mathematics for Lean 4.
+    - `mathlib`: The local name given to this dependency.
+    - `from git "..."`: Specifies that `mathlib4` should be fetched from the given GitHub repository URL.
+    - `@ "v4.15.0"`: This is a crucial part that "pins" the dependency to a specific version (tag `v4.15.0`) of `mathlib4`. This ensures that the project always builds against this exact version, providing reproducibility and stability.
+
+- **`@[default_target] lean_lib «clever» where ...`**:
+    - This block defines a Lean library target named "clever".
+    - `@[default_target]`: This attribute marks the "clever" library as the default target. When a user runs `lake build` without specifying a particular target, Lake will build this library.
+    - **`globs := #[.submodules \`Imports, .submodules \`human_eval, .submodules \`sample_examples]`**: This directive tells Lake where to find the source files (`.lean` files) for the "clever" library. It specifies that all Lean files within the subdirectories named `Imports`, `human_eval`, and `sample_examples` are part of this library. These directories likely contain:
+        - `Imports`: Common import files or utility definitions for the project.
+        - `human_eval`: Lean files related to human evaluation tasks or problems.
+        - `sample_examples`: Lean files containing sample problems or examples.
+
+## Important Variables/Constants
+In the context of a `lakefile.lean`, these are more like configuration parameters:
+
+- **Package Name**: `«clever»` - The name of the Lean package.
+- **Lean Compiler Options (`leanOptions`)**:
+    - `autoImplicit := false`: A specific compiler behavior setting.
+- **Dependency URIs and Revisions**:
+    - `mathlib` git URL: `https://github.com/leanprover-community/mathlib4`
+    - `mathlib` version: `v4.15.0`
+- **Library Source Locations (`globs`)**: The paths (`Imports`, `human_eval`, `sample_examples`) that define the content of the main library.
+
+## Usage Examples
+This file is not "run" or "imported" in the way a typical Python or Lean source file is. Instead, it is used by the `lake` command-line tool. Here's how it's typically used from a terminal within the `src/lean4/` directory (which is the root of this Lean project):
+
+- **`lake build`**:
+    - This command instructs Lake to build the default target, which is the `«clever»` library defined in this file. Lake will:
+        1. Read `lakefile.lean`.
+        2. Download and build `mathlib v4.15.0` if it hasn't been built already with these settings.
+        3. Compile all `.lean` files found in the `Imports`, `human_eval`, and `sample_examples` directories, using the `autoImplicit := false` option.
+        4. Place compiled artifacts (e.g., `.olean` files) into the `build` directory.
+
+- **`lake clean`**:
+    - This command removes the `build` directory, cleaning up compiled files.
+
+- **`lake update`**:
+    - This command would attempt to update dependencies to their latest compatible versions, but since `mathlib` is pinned to a specific revision (`v4.15.0`), `lake update mathlib` would only change something if the `lakefile.lean` itself was modified to a different revision.
+
+- **`lake lean <file_name>`**:
+    - This command can be used to compile a single Lean file, for example, `lake lean human_eval/problem_1.lean`. It would still respect the package configurations and dependencies defined in `lakefile.lean`.
+
+## Dependencies and Interactions
+- **Lean 4 Toolchain**: This `lakefile.lean` requires a working Lean 4 installation, as `lake` is part of Lean 4.
+- **`mathlib4` (version `v4.15.0`)**: The "clever" package explicitly depends on this specific version of the Mathlib 4 library. The source code within the `Imports`, `human_eval`, and `sample_examples` directories can use any definitions and theorems provided by this version of `mathlib`.
+- **File System Structure**: The `globs` directive means this `lakefile.lean` expects subdirectories named `Imports`, `human_eval`, and `sample_examples` to exist and contain the project's Lean source files.
+- **Git**: `lake` uses `git` in the background to fetch dependencies like `mathlib` from Git repositories.

--- a/docs/lean_parser_spec.md
+++ b/docs/lean_parser_spec.md
@@ -1,0 +1,113 @@
+# src/clever_bench/lean_parser_spec.py
+
+## Overview
+The `src/clever_bench/lean_parser_spec.py` file provides the `LeanSpecParser` class, designed to parse structured Lean code files. These files are expected to contain specific comment-delimited sections that define theorem proving problems, including their metadata, formal specifications, implementations, proofs, and associated helper lemmas. The parser extracts this information and organizes it into a `LeanProblem` object. A key feature is its ability to selectively include common helper definitions based on the problem's ID and whether it's designated as a sample problem, by parsing metadata embedded in the helper definition files.
+
+## Key Components
+- **`LeanSpecParser` class**:
+    - `__init__(self, lean_code: str, helper_definitions: str = None, problem_id: int = None, is_sample: bool = False)`: Constructor that initializes the parser with the Lean code content, an optional string of shared helper definitions, a unique problem identifier, and a boolean flag indicating if the problem is a sample. It pre-processes the `lean_code` by calling `_extract_sections`.
+    - `_extract_sections(self) -> dict`: Uses regular expressions to identify and extract content from specially formatted comment blocks (e.g., `-- start_def SECTION_NAME ... -- end_def SECTION_NAME`). The extracted sections are stored in a dictionary, where keys are section names and values are lists of strings (content of each section).
+    - `_parse_helper_definitions(self) -> List[str]`: If `helper_definitions` are provided, this method parses them to find relevant definitions for the current `problem_id` and `is_sample` status. It looks for YAML metadata within comment blocks in the helper definitions to determine which definitions to include.
+    - `_parse_yaml_block(self, raw: str) -> Optional[ProblemSpecMetadata]`: Parses YAML content embedded within a comment block (typically `/-- ... --/`). It extracts fields like `function_signature`, `docstring`, and `test_cases` and populates a `ProblemSpecMetadata` object. Returns `None` if parsing fails or no YAML block is found.
+    - `_get_lemmas(self, prefix: str) -> List[Lemma]`: Constructs a list of `Lemma` objects. It retrieves lemma statements and their corresponding proofs from the extracted sections based on a given `prefix` (e.g., `iso_helper_lemmas` for statements and `iso_helper_lemmas_proof` for proofs).
+    - `_get_first(self, key: str) -> Optional[str]`: A utility method to retrieve the first string from a list of section contents associated with a `key`, or `None` if the section is empty or not found.
+    - `parse(self) -> LeanProblem`: The main public method that drives the parsing process. It calls the various private methods to extract all necessary components (metadata, specifications, implementation, lemmas, etc.) from the `lean_code` and `helper_definitions`, and then instantiates and returns a `LeanProblem` object.
+
+## Important Variables/Constants
+- **`LeanSpecParser.lean_code: str`**: The raw Lean code string provided to the parser instance.
+- **`LeanSpecParser.helper_definitions: Optional[str]`**: An optional string containing Lean definitions that can be shared across multiple problems.
+- **`LeanSpecParser.problem_id: Optional[int]`**: An identifier for the specific problem being parsed, used for linking with specific helper definitions.
+- **`LeanSpecParser.is_sample: bool`**: A flag to indicate if the problem is a sample problem, which can affect which helper definitions are loaded.
+- **`LeanSpecParser.sections: dict`**: A dictionary populated by `_extract_sections`, holding the raw string content of different parts of the Lean problem file, keyed by section names.
+- **Regular Expression Patterns**: Implicitly, the regex patterns used in `_extract_sections` and `_parse_helper_definitions` are crucial for correctly identifying and delimiting the sections within the Lean code and helper files.
+
+## Usage Examples
+```python
+from clever_bench.lean_parser_spec import LeanSpecParser
+from clever_bench.lean_problem import LeanProblem # For context and type hint
+
+# --- Example Lean Code (simplified) ---
+lean_file_content = """
+-- start_def problem_details
+/--
+function_signature: "def add_one (n: Nat) : Nat"
+docstring: "Adds one to a natural number."
+test_cases:
+  - "add_one 0 = 1"
+  - "add_one 5 = 6"
+-/
+-- end_def problem_details
+
+-- start_def problem_spec
+theorem add_one_spec (n: Nat) : add_one n = n + 1 :=
+sorry
+-- end_def problem_spec
+
+-- start_def implementation
+def add_one (n: Nat) : Nat :=
+  n + 1
+-- end_def implementation
+"""
+
+# --- Example Helper Definitions (simplified) ---
+helper_definitions_content = """
+-- start_def helper_definitions
+/--
+problems: [101, 102]
+sample_problems: [1] 
+-/
+def common_nat_lemma : True := trivial
+-- end_def helper_definitions
+
+-- start_def helper_definitions
+/--
+problems: [103]
+-/
+def specific_lemma_for_103 : True := trivial
+-- end_def helper_definitions
+"""
+
+# --- Parsing a standard problem ---
+# Assume this is problem 101
+parser_std = LeanSpecParser(
+    lean_code=lean_file_content,
+    helper_definitions=helper_definitions_content,
+    problem_id=101,
+    is_sample=False
+)
+problem_std: LeanProblem = parser_std.parse()
+
+print(f"Standard Problem ID: {problem_std.problem_id}")
+if problem_std.problem_spec_metadata:
+    print(f"Signature: {problem_std.problem_spec_metadata.function_signature}")
+# This problem (101) should load 'common_nat_lemma'
+print(f"Helper definitions loaded: {len(problem_std.helper_definitions)}")
+if len(problem_std.helper_definitions) > 0:
+    print(f"First helper: {problem_std.helper_definitions[0][:50]}...") # Print start of helper
+
+# --- Parsing a sample problem ---
+# Assume this is sample problem 1
+parser_sample = LeanSpecParser(
+    lean_code=lean_file_content, # Using same content for simplicity
+    helper_definitions=helper_definitions_content,
+    problem_id=1,
+    is_sample=True
+)
+problem_sample: LeanProblem = parser_sample.parse()
+
+print(f"Sample Problem ID: {problem_sample.problem_id}")
+# This sample problem (1) should also load 'common_nat_lemma'
+print(f"Helper definitions loaded: {len(problem_sample.helper_definitions)}")
+if len(problem_sample.helper_definitions) > 0:
+    print(f"First helper: {problem_sample.helper_definitions[0][:50]}...")
+```
+
+## Dependencies and Interactions
+- **`re` (Regular Expressions)**: Heavily used for pattern matching to find and extract the specially delimited sections within the Lean code (e.g., `re.compile`, `pattern.finditer`).
+- **`yaml` (`PyYAML`)**: Used to parse YAML blocks found within comments (specifically `/-- ... --/`) to extract structured metadata like function signatures, docstrings, and test cases (`yaml.safe_load`).
+- **`clever_bench.lean_problem.LeanProblem`**: This is the primary output data structure. The `LeanSpecParser` populates instances of `LeanProblem` with the information it extracts. This is an internal dependency from another module in the same project.
+- **`clever_bench.lean_problem.ProblemSpecMetadata`**: A data class (likely Pydantic or a standard dataclass) used to hold the structured metadata parsed from the YAML blocks.
+- **`clever_bench.lean_problem.Lemma`**: A data class used to represent a lemma, typically containing its statement and proof.
+- **`typing.List`, `typing.Optional`**: Standard Python typing library used for type hinting to improve code clarity and robustness.
+- **Input Lean Files**: The parser expects Lean files (`.lean`) or strings of Lean code that adhere to a specific commenting convention (e.g., `-- start_def ... -- end_def ...`) for structuring different parts of a problem definition.
+- **Helper Definition Files**: Similarly, any provided helper definition strings are expected to follow a similar structure, with additional YAML metadata to specify which problems or sample problems each helper block applies to.

--- a/docs/lean_problem.md
+++ b/docs/lean_problem.md
@@ -1,0 +1,124 @@
+# src/clever_bench/lean_problem.py
+
+## Overview
+The `src/clever_bench/lean_problem.py` file defines the core data structures for representing Lean theorem-proving problems within the `clever_bench` framework. It specifies the various components that constitute a problem, such as its metadata (including Python function signatures and docstrings), natural language descriptions, formal Lean specifications (both ground truth and potentially machine-generated versions), implementations, correctness theorems, and associated proofs. The file also includes structures for helper lemmas and an enumeration (`TaskComponent`) to categorize different benchmark tasks (e.g., specification generation, proof generation). Utilities are provided to serialize these problem structures into formats like JSON and CSV, and to format them back into Lean code with line number tracking for specific sections.
+
+## Key Components
+- **`TaskComponent(Enum)`**: An enumeration that defines distinct categories of tasks within the benchmark. Examples include:
+    - `SPEC_GENERATION`: Generating formal Lean specifications from natural language.
+    - `IMPL_GENERATION`: Generating Lean code implementations from specifications.
+    - `PROOF_GENERATION`: Generating proofs for theorems (e.g., correctness proofs).
+    - `SPEC_ISOMORPHISM`: Proving equivalence between different formal specifications.
+- **`@dataclass Lemma`**: A simple data class representing a Lean lemma.
+    - `statement: str`: The Lean statement of the lemma.
+    - `proof: str`: The Lean proof of the lemma.
+    - `to_dict(self)`: Converts the lemma to a dictionary.
+- **`@dataclass ProblemSpecMetadata`**: A data class for storing metadata associated with a problem's specification.
+    - `function_signature: str`: The Python function signature related to the problem.
+    - `docstring: str`: The docstring describing the function or problem.
+    - `test_cases: List[Dict]`: A list of dictionaries, presumably representing test cases (e.g., input/output pairs).
+    - `to_dict(self)`: Converts the metadata to a dictionary.
+- **`@dataclass LeanProblem`**: The main data class that encapsulates all information for a single Lean problem.
+    - `problem_id: int`: A unique integer identifier for the problem.
+    - `problem_spec_metadata: Optional[ProblemSpecMetadata]`: Metadata including Python signature, docstring, etc.
+    - `problem_spec_nl: Optional[str]`: Natural language description of the problem.
+    - `problem_spec_formal_ground_truth: Optional[str]`: The definitive formal Lean specification.
+    - `problem_spec_formal_generated: Optional[str]`: A machine-generated formal Lean specification.
+    - `isomorphism_theorem: Optional[str]`: Theorem statement for specification isomorphism.
+    - `isomorphism_proof: Optional[str]`: Proof for specification isomorphism.
+    - `implementation_signature: Optional[str]`: Lean signature for the implementation.
+    - `implementation: Optional[str]`: The Lean code implementation.
+    - `test_cases_lean: Optional[str]`: Lean-based test cases.
+    - `correctness_theorem: Optional[str]`: Theorem statement for the correctness of the implementation.
+    - `correctness_proof: Optional[str]`: Proof for the correctness theorem.
+    - `helper_definitions: List[str]`: List of shared Lean definitions/imports.
+    - `isomorphism_helper_lemmas: List[Lemma]`: Helper lemmas for the isomorphism proof.
+    - `correctness_helper_lemmas: List[Lemma]`: Helper lemmas for the correctness proof.
+    - `to_dict(self) -> Dict[str, Any]`: Serializes the `LeanProblem` to a dictionary.
+    - `to_json(self) -> str`: Serializes the `LeanProblem` to a JSON string.
+    - `to_csv(self) -> tuple[List[str], List[str]]`: Converts the problem data into a flat list of headers and a list of values for CSV output.
+- **`@dataclass LeanProblemView`**: A data class designed to offer a specific "view" or subset of a `LeanProblem`'s data, tailored for a particular `TaskComponent`. It shares many fields with `LeanProblem` but `problem_id` is a string.
+    - `task_component: TaskComponent`: Indicates the task for which this view is relevant.
+    - `hide_params(self, *args)`: A method to selectively set specified attributes to `None` or empty lists, effectively "hiding" them for certain use cases.
+- **`format_problem_as_lean_with_line_ranges(problem: LeanProblemView) -> tuple[str, dict]`**: A function that takes a `LeanProblemView` and generates a multi-line string representing the problem in Lean code format. It also returns a dictionary mapping labels (e.g., "isomorphism", "correctness") to tuples representing the start and end line numbers of those sections in the generated string. If proofs are missing, they default to `by sorry`.
+
+## Important Variables/Constants
+The fields within the dataclasses are the primary "variables." Key attributes include:
+- `LeanProblem.problem_id`: The unique identifier.
+- `LeanProblem.problem_spec_formal_ground_truth`: The canonical Lean specification.
+- `LeanProblem.implementation`: The Lean code solution.
+- `LeanProblem.correctness_theorem` and `LeanProblem.correctness_proof`: Crucial for verifying the implementation.
+- `LeanProblemView.task_component`: Determines the context for the view.
+
+## Usage Examples
+```python
+from clever_bench.lean_problem import (
+    LeanProblem, ProblemSpecMetadata, Lemma, TaskComponent,
+    LeanProblemView, format_problem_as_lean_with_line_ranges
+)
+
+# 1. Define metadata and lemmas
+metadata = ProblemSpecMetadata(
+    function_signature="def square (n: Nat) : Nat",
+    docstring="Squares a natural number.",
+    test_cases=[{"input": "square 3", "output": "9"}]
+)
+helper_lemma = Lemma(statement="theorem helper_sq: 1 * 1 = 1", proof="rfl")
+
+# 2. Create a LeanProblem instance
+problem = LeanProblem(
+    problem_id=1,
+    problem_spec_metadata=metadata,
+    problem_spec_nl="Write a Lean function that squares a natural number and prove its correctness.",
+    problem_spec_formal_ground_truth="theorem square_spec (n: Nat) : square n = n * n := by sorry",
+    implementation_signature="def square (n: Nat) : Nat :=",
+    implementation="  n * n",
+    correctness_theorem="theorem square_correct (n: Nat) : square n = n * n := by sorry",
+    correctness_proof=None, # To be filled by a proof generation task
+    helper_definitions=["import Mathlib.Tactic"],
+    correctness_helper_lemmas=[helper_lemma]
+)
+
+# 3. Serialize to JSON
+print(f"Problem JSON: {problem.to_json(indent=2)}")
+
+# 4. Create a LeanProblemView for a specific task (e.g., proof generation)
+proof_gen_view = LeanProblemView(
+    problem_id=str(problem.problem_id),
+    task_component=TaskComponent.PROOF_GENERATION,
+    problem_spec_formal_ground_truth=problem.problem_spec_formal_ground_truth,
+    implementation_signature=problem.implementation_signature,
+    implementation=problem.implementation,
+    correctness_theorem=problem.correctness_theorem,
+    correctness_proof=problem.correctness_proof, # This would be None or "by sorry"
+    helper_definitions=problem.helper_definitions,
+    correctness_helper_lemmas=problem.correctness_helper_lemmas
+)
+
+# 5. Format the view as Lean code with line ranges
+lean_code, ranges = format_problem_as_lean_with_line_ranges(proof_gen_view)
+print(f"\nFormatted Lean Code for Proof Generation:\n{lean_code}")
+print(f"\nLine Ranges for Proof Section: {ranges.get('correctness')}")
+
+# Example: If the task was implementation generation, the implementation might be hidden/None
+impl_gen_view = LeanProblemView(
+    problem_id=str(problem.problem_id),
+    task_component=TaskComponent.IMPL_GENERATION,
+    problem_spec_formal_ground_truth=problem.problem_spec_formal_ground_truth,
+    implementation_signature=problem.implementation_signature,
+    implementation=None, # This would be the part to generate
+    correctness_theorem=problem.correctness_theorem
+)
+impl_gen_view.hide_params("correctness_proof", "isomorphism_proof") # Hide irrelevant proofs
+lean_code_impl, _ = format_problem_as_lean_with_line_ranges(impl_gen_view)
+print(f"\nFormatted Lean Code for Implementation Generation:\n{lean_code_impl}")
+
+```
+
+## Dependencies and Interactions
+- **`dataclasses`**: Python's built-in module used extensively for creating structured data classes (`@dataclass`, `field`, `asdict`).
+- **`typing`**: Standard Python module for type hints (`List`, `Optional`, `Dict`, `Any`).
+- **`enum`**: Standard Python module for creating enumerations (`Enum`, `auto`).
+- **`json`**: Python's built-in JSON library, used in `LeanProblem.to_json()` and internally by `LeanProblem.to_csv()` for serializing list/dict fields.
+- **Interaction with `LeanSpecParser`**: The `LeanProblem` objects are typically instantiated and populated by `LeanSpecParser` (from `lean_parser_spec.py`) after it parses Lean files.
+- **Output Formatting**: The `format_problem_as_lean_with_line_ranges` function produces Lean code strings that are likely consumed by other tools or processes that need to interact with or display Lean problems in a structured textual format.

--- a/docs/score_solutions.md
+++ b/docs/score_solutions.md
@@ -1,0 +1,122 @@
+# src/scripts/score_solutions.py
+
+## Overview
+The `src/scripts/score_solutions.py` script is a command-line tool designed to automatically score solutions for tasks within a Lean project. It operates by analyzing a Lean build log file to detect the presence of `sorry` placeholders associated with specific tasks. If a task has no remaining `sorry`s in its relevant files (as indicated by the build log), it is considered complete and awarded a predefined score. Otherwise, it receives a score of zero. The script reads task definitions and their potential scores from a JSON summary file and outputs the results to another JSON file and the console.
+
+## Key Components
+The script's functionality is primarily contained within the `main()` function.
+
+- **`main()` function**:
+    - **Argument Parsing**: Initializes `argparse` to accept command-line arguments: `--build_log`, `--task_summary_file`, and `--score_file`.
+    - **File Reading**:
+        - Reads the content of the Lean build log specified by `--build_log`.
+        - Reads and parses the JSON task summary specified by `--task_summary_file`. This file contains a list of tasks, each with a name and a potential score.
+    - **Scoring Logic**:
+        - Iterates through each task defined in the task summary.
+        - For each `task_name`, it dynamically constructs a regular expression: `rf"{task_name}:\d+:\d+:([\s]*)declaration uses 'sorry'"`. This regex is designed to find lines in the build log that indicate a `sorry` was used within a file or declaration associated with that `task_name`.
+        - It uses `re.compile` and `task_regex.findall(build_log)` to find all occurrences matching this pattern for the current task.
+        - If no matches are found (i.e., `len(problems) == 0`), the task is considered successfully completed, and its predefined `score` (from the task summary) is awarded.
+        - If matches are found, the task is considered incomplete, and a score of 0 is awarded.
+        - Progress messages for each task (done or incomplete) are printed to the console.
+    - **Output**:
+        - Stores the calculated scores in a dictionary (`scores`) mapping task names to their awarded points.
+        - Ensures the output directory for the score file exists (e.g., `src/lean4/temp/`).
+        - Writes the `scores` dictionary to the JSON file specified by `--score_file`.
+        - Prints the content of the score file and the total sum of scores to the console.
+
+## Important Variables/Constants
+- **Command-Line Arguments**:
+    - **`--build_log`**:
+        - Type: `str`
+        - Default: `src/lean4/lean4_build.log`
+        - Purpose: Specifies the path to the Lean build log file. This file is crucial as it's parsed for "sorry" messages.
+    - **`--task_summary_file`**:
+        - Type: `str`
+        - Default: `src/lean4/task_summary.json`
+        - Purpose: Specifies the path to a JSON file that lists all tasks to be scored. Each task entry should include at least `"task_name"` and `"score"` (the maximum points for that task).
+    - **`--score_file`**:
+        - Type: `str`
+        - Default: `src/lean4/temp/score.json`
+        - Purpose: Specifies the path where the output JSON file containing the scores will be saved.
+
+- **Key Internal Variables**:
+    - `build_log` (string): Stores the entire content of the build log file.
+    - `task_summary` (dict): Stores the parsed content of the task summary JSON.
+    - `tasks` (list of dicts): Extracted list of task objects from `task_summary["tasks"]`.
+    - `scores` (dict): Accumulates the scores for each task, with task names as keys.
+    - `rexp` (string): The dynamically generated regular expression pattern used to find `sorry` messages related to a specific task.
+    - `task_regex` (compiled regex object): The compiled version of `rexp` for efficient searching.
+
+## Usage Examples
+To use the script, you would typically run it from the command line after a Lean build process has completed and generated a build log.
+
+1.  **Using default file paths**:
+    If your build log is at `src/lean4/lean4_build.log` and your task summary is at `src/lean4/task_summary.json`, you can run:
+    ```bash
+    python src/scripts/score_solutions.py
+    ```
+
+2.  **Specifying custom file paths**:
+    ```bash
+    python src/scripts/score_solutions.py \
+        --build_log /path/to/my_project_build.log \
+        --task_summary_file /path/to/custom_tasks.json \
+        --score_file /path/to/output/final_scores.json
+    ```
+
+**Example `task_summary.json` content**:
+```json
+{
+  "tasks": [
+    {
+      "task_name": "Problem1_Proof",
+      "score": 10
+    },
+    {
+      "task_name": "Problem2_Implementation",
+      "score": 15
+    },
+    {
+      "task_name": "Problem3_Spec",
+      "score": 5
+    }
+  ]
+}
+```
+
+**Interpreting Output**:
+- **Console Output**:
+    ```
+    Task Problem1_Proof done successfully.
+    Task Problem2_Implementation incomplete.
+    Task Problem3_Spec done successfully.
+    {
+        "Problem1_Proof": 10,
+        "Problem2_Implementation": 0,
+        "Problem3_Spec": 5
+    }
+    Total score: 15
+    ```
+- **Score File (`--score_file`)**:
+    The JSON file (e.g., `src/lean4/temp/score.json`) would contain:
+    ```json
+    {
+        "Problem1_Proof": 10,
+        "Problem2_Implementation": 0,
+        "Problem3_Spec": 5
+    }
+    ```
+
+## Dependencies and Interactions
+- **Python Standard Libraries**:
+    - `os`: Used for file system interactions like checking path existence (`os.path.exists`) and creating directories (`os.makedirs`).
+    - `json`: Essential for reading the `--task_summary_file` and writing the `--score_file`.
+    - `argparse`: Used for parsing command-line arguments provided to the script.
+    - `re`: The regular expression library, critical for searching the build log for patterns indicating `sorry` placeholders.
+
+- **File Formats & External Data**:
+    - **Lean Build Log (`--build_log`)**: The script assumes this is a text file generated by a Lean build process (e.g., `lake build > lean4_build.log`). The accuracy of scoring heavily depends on the format of "sorry" messages in this log. Specifically, it expects messages like: `[task_name]:[line]:[column]: declaration uses 'sorry'`, where `[task_name]` matches a name in the `task_summary.json`.
+    - **Task Summary JSON (`--task_summary_file`)**: This input JSON file must conform to a structure where a top-level key `"tasks"` holds a list of objects, each object having at least a `"task_name"` (string) and a `"score"` (numeric value).
+    - **Output Score JSON (`--score_file`)**: The script produces a JSON file containing a simple dictionary mapping task names (strings) to their awarded scores (numbers).
+
+- **Lean Build Process**: Implicitly, the script relies on a preceding Lean build process that generates the build log. The content and format of this log are vital for the script's operation. The `task_name` used in the log messages (e.g., derived from file names or specific Lean project configurations) must align with the `task_name` entries in the `task_summary.json` for accurate scoring.

--- a/docs/task.md
+++ b/docs/task.md
@@ -1,0 +1,166 @@
+# src/clever_bench/task.py
+
+## Overview
+The `src/clever_bench/task.py` file defines a system for managing and evaluating tasks related to Lean problems sourced from a `Benchmark`. The central class, `ProblemViewTask`, is responsible for preparing `LeanProblemView` objects tailored to specific `TaskComponent`s (e.g., proof generation, implementation generation). It then orchestrates the "submission" of these views by writing them to temporary Lean files, compiling them using Lean's build tool `lake`, and analyzing the compiler output to validate the submission (e.g., checking for `sorry` placeholders or compilation errors). The module supports asynchronous submissions and generates reports detailing the validation outcomes.
+
+## Key Components
+- **`ValidationResult = namedtuple(...)`**: A named tuple used to encapsulate the results of validating a single problem submission.
+    - `problem_id: str`: Identifier of the problem.
+    - `isomorphism_ok: bool`: True if the isomorphism proof (if applicable) is valid.
+    - `correctness_ok: bool`: True if the correctness proof (if applicable) is valid.
+    - `compilation_ok: bool`: True if the Lean code compiled successfully.
+    - `error_message: str`: Contains error messages from compilation or reasons for validation failure (e.g., "Timeout", "Sorries found").
+    - `lean_code: str`: The actual Lean code that was submitted and validated.
+
+- **`ProblemViewTask` class**:
+    - `__init__(self, benchmark: Benchmark, component: TaskComponent, lean_folder: str = None, report_dir: str = ".logs/reports")`:
+        - Initializes the task with a `Benchmark` instance, a `TaskComponent` (e.g., `TaskComponent.PROOF_GENERATION`), an optional path to the Lean project (`lean_folder`), and a directory for saving reports (`report_dir`).
+        - Creates a timestamped subdirectory within `report_dir` for storing results of the current run.
+        - Ensures a `temp` directory exists within the Lean project folder for temporary files.
+    - `get_view(self, idx: int) -> LeanProblemView`:
+        - Fetches a `LeanProblem` by its ID from the `benchmark`.
+        - Converts it into a `LeanProblemView`.
+        - Modifies the view based on `self.component` by selectively hiding certain fields (e.g., if `component` is `PROOF_GENERATION`, existing proofs are hidden to set up the task of generating them). It also processes test cases to uncomment them.
+    - `get_visible_problems(self) -> list[LeanProblemView]`:
+        - Iterates through all problems in the `benchmark`.
+        - For each problem, calls `get_view` to create a task-specific view.
+        - Returns a list of these prepared `LeanProblemView` objects.
+    - `submit_async(self, problem: LeanProblemView, timeout_in_ms: float) -> ValidationResult`:
+        - Asynchronously validates a submitted `LeanProblemView` (which typically contains model-generated code/proofs).
+        - Reconstructs the original problem view and updates it with the submitted content (e.g., generated proofs).
+        - Formats the updated view into a Lean code string using `format_problem_as_lean_with_line_ranges`.
+        - Writes this code to a unique temporary `.lean` file in the `lean_folder_path / "temp"` directory.
+        - Executes `lake lean <temp_file.name>` as an asynchronous subprocess within the Lean project's context.
+        - Handles timeouts and compilation errors, returning appropriate `ValidationResult`.
+        - If compilation is successful, it parses the output using `_extract_sorry_lines` to detect any remaining `sorry` placeholders.
+        - Determines `isomorphism_ok` and `correctness_ok` based on the presence of proofs and absence of sorries (though the current logic is simplified in the main path).
+        - Deletes the temporary Lean file upon completion.
+    - `_extract_sorry_lines(self, build_log: str, filename: str) -> list[int]`:
+        - Parses the build log (output from `lake lean`) to find line numbers where the compiler reports `sorry` for the given `filename`.
+    - `_check_sorries_against_ranges(...)`: (Helper method, currently seems bypassed by simpler logic in `submit_async` for final pass/fail of proofs). Intended to check if `sorry` lines fall within specific line ranges designated for proofs (e.g., isomorphism proof range).
+    - `submit_benchmark_and_get_report(self, solutions: list[LeanProblemView], timeout_in_ms_per_problem: float)`:
+        - Takes a list of `LeanProblemView` objects representing solutions.
+        - Uses `asyncio.gather` to run `submit_async` for all solutions concurrently.
+        - Collects all `ValidationResult`s.
+        - Saves the Lean code of each submission to a file in the `self.report_dir`.
+        - Writes a `results.json` file containing a summary of `isomorphism_ok` and `correctness_ok` for each problem.
+        - Prints an aggregated report to the console, including success rates for different proof types.
+
+## Important Variables/Constants
+- **`ProblemViewTask.benchmark: Benchmark`**: The collection of Lean problems to work with.
+- **`ProblemViewTask.component: TaskComponent`**: Defines the nature of the task (e.g., what part of the problem is to be generated or validated).
+- **`ProblemViewTask.lean_folder_path: Path`**: The file system path to the root of the Lean project. This is crucial for running `lake` commands correctly.
+- **`ProblemViewTask.report_dir: Path`**: The directory where reports and submitted Lean files are stored.
+- **`lake lean` command**: The external Lean compiler/build command used for validation.
+
+## Usage Examples
+```python
+import asyncio
+from pathlib import Path
+from clever_bench.benchmark import Benchmark
+from clever_bench.task import ProblemViewTask, TaskComponent
+from clever_bench.lean_problem import LeanProblemView, LeanProblem, ProblemSpecMetadata
+
+# --- Setup a dummy Benchmark for the example ---
+# In a real scenario, benchmark would be loaded with actual problems.
+dummy_meta = ProblemSpecMetadata(function_signature="def add_one (n:Nat):Nat", docstring="Adds one.", test_cases=[])
+dummy_problem = LeanProblem(
+    problem_id=0, problem_spec_metadata=dummy_meta,
+    problem_spec_nl="A function that adds one to a natural number.",
+    problem_spec_formal_ground_truth="theorem add_one_spec (n:Nat) : add_one n = n + 1 := by sorry",
+    implementation_signature="def add_one (n:Nat) : Nat :=",
+    implementation="  n + 1",
+    correctness_theorem="theorem add_one_correct (n:Nat) : add_one n = n + 1 := by sorry" # Target for proof
+)
+benchmark_instance = Benchmark()
+benchmark_instance.problems = [dummy_problem]
+
+# --- Setup a dummy Lean project for 'lake' to run ---
+# This is necessary if the default project path isn't suitable for testing.
+lean_project_dir = Path("temp_lean_project_for_docs")
+lean_project_dir.mkdir(exist_ok=True)
+(lean_project_dir / "lakefile.lean").write_text("import Lake\nopen Lake DSL\npackage temp_proj {}")
+(lean_project_dir / "Main.lean").write_text("def main := IO.println \"Hello\"") # A minimal main file
+imports_dir = lean_project_dir / "Imports"
+imports_dir.mkdir(exist_ok=True)
+(imports_dir / "AllImports.lean").write_text("import Mathlib.Tactic -- Or any other common import")
+# You would need to run `lake build` once manually in `temp_lean_project_for_docs` if Mathlib is new.
+
+# 1. Initialize ProblemViewTask for a specific task (e.g., PROOF_GENERATION)
+# Ensure 'lake' is in PATH.
+proof_generation_task = ProblemViewTask(
+    benchmark=benchmark_instance,
+    component=TaskComponent.PROOF_GENERATION,
+    lean_folder=str(lean_project_dir) # Point to our dummy Lean project
+)
+
+# 2. Get all problems formatted for this task
+# (Proofs would be hidden, prompting the "model" to generate them)
+problem_views_for_task = proof_generation_task.get_visible_problems()
+
+# 3. Simulate a model providing solutions
+# For this example, we'll manually create a "solved" view for the first problem.
+solutions_to_validate = []
+if problem_views_for_task:
+    task_view = problem_views_for_task[0]
+    
+    # Construct a solution view (normally from a model's output)
+    # Key part is filling in the field corresponding to the task component.
+    # For PROOF_GENERATION, this is often `correctness_proof`.
+    solved_view = LeanProblemView(
+        problem_id=task_view.problem_id, # Must match the problem being solved
+        task_component=task_view.task_component,
+        
+        # Copy other necessary fields from the task_view
+        problem_spec_formal_ground_truth=task_view.problem_spec_formal_ground_truth,
+        implementation_signature=task_view.implementation_signature,
+        implementation=task_view.implementation,
+        correctness_theorem=task_view.correctness_theorem,
+        helper_definitions=task_view.helper_definitions,
+        correctness_helper_lemmas=task_view.correctness_helper_lemmas,
+        # ... any other fields required by format_problem_as_lean_with_line_ranges
+
+        # The "generated" content:
+        correctness_proof="simp [Nat.add_one]" # Example proof
+    )
+    solutions_to_validate.append(solved_view)
+
+# 4. Submit the "solved" problems and get a report
+if solutions_to_validate:
+    print(f"Submitting {len(solutions_to_validate)} solution(s) for validation...")
+    # The results (pass/fail, errors) are printed to console and saved to files
+    # in the '.logs/reports/<timestamp>/' directory by default.
+    validation_results = proof_generation_task.submit_benchmark_and_get_report(
+        solutions=solutions_to_validate,
+        timeout_in_ms_per_problem=15000 # 15 seconds timeout per problem
+    )
+    # print(f"Validation outcome for problem {validation_results[0].problem_id}: Correctness OK = {validation_results[0].correctness_ok}")
+else:
+    print("No solutions were prepared for submission.")
+
+# --- Clean up dummy project (optional) ---
+# import shutil
+# shutil.rmtree(lean_project_dir)
+# Also, consider cleaning '.logs/reports' if running tests repeatedly.
+```
+
+## Dependencies and Interactions
+- **`asyncio`**: Used for running Lean compilation (`lake lean`) as an asynchronous subprocess, allowing for concurrent validation of multiple problems and handling timeouts.
+- **`uuid`**: For generating unique names for temporary Lean files created during validation.
+- **`os`**: For basic file system operations like creating directories (`os.makedirs`).
+- **`time`**: Used to create timestamped directories for storing reports, helping to organize results from different runs.
+- **`pathlib.Path`**: For modern, object-oriented file system path manipulations.
+- **`collections.namedtuple`**: Used to define the `ValidationResult` data structure.
+- **`clever_bench.lean_problem`**: This module is a key dependency, providing:
+    - `LeanProblemView`: The data structure for representing a problem instance tailored to a specific task.
+    - `TaskComponent`: The enumeration used to define the type of task.
+    - `format_problem_as_lean_with_line_ranges`: The function used to convert a `LeanProblemView` into a Lean code string for compilation.
+- **`clever_bench.benchmark`**:
+    - `Benchmark`: The class that provides the source of `LeanProblem` objects.
+    - `get_clever_lean_project_path`: A utility function to find the path to the Lean project.
+- **External Tool: `lake`**: The Lean build system and package manager. `ProblemViewTask` relies on `lake` being installed and accessible in the system's PATH to compile and check Lean code. The command `lake lean <file>` is executed as a subprocess.
+- **File System**: The class interacts heavily with the file system for:
+    - Creating report directories.
+    - Creating temporary Lean files (`*.lean`) for compilation.
+    - Reading Lean project configuration (implicitly, via `lake`).
+    - Writing out submitted Lean code and JSON summary reports.

--- a/documentation_template.md
+++ b/documentation_template.md
@@ -1,0 +1,18 @@
+# {file_name}
+
+## Overview
+{overview}
+
+## Key Components
+{key_components}
+
+## Important Variables/Constants
+{important_variables_constants}
+
+## Usage Examples
+```python
+{usage_examples}
+```
+
+## Dependencies and Interactions
+{dependencies_interactions}


### PR DESCRIPTION
… files:

This commit introduces Markdown documentation for key source code files, outlining their overview, components, variables, usage, and dependencies.

The following files have been documented:
- src/clever_bench/benchmark.py
- src/clever_bench/lean_parser_spec.py
- src/clever_bench/lean_problem.py
- src/clever_bench/task.py
- src/lean4/lakefile.lean
- src/scripts/score_solutions.py

I used a consistent template for all documentation files, which are now located in the new `docs/` directory.